### PR TITLE
fix(athena-led): migrate incompatible legacy config 修复Athena LED plugin 

### DIFF
--- a/files/etc/uci-defaults/99-athena-led-config-migration
+++ b/files/etc/uci-defaults/99-athena-led-config-migration
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+CONFIG="/etc/config/athena_led"
+ROM_CONFIG="/rom/etc/config/athena_led"
+BACKUP_BASE="/etc/config/athena_led.config-migrated"
+
+[ -f "$CONFIG" ] || exit 0
+
+# The older Athena LED package used athena_led.config.enable/lightLevel/tempFlag.
+# luci-app-athena-led 2.x reads athena_led.general.enabled/light_level/temp_sensors
+# instead, so a kept sysupgrade config prevents the service from starting.
+if ! uci -q get athena_led.config.enable >/dev/null 2>&1 &&
+	! grep -q "config athena_led 'config'" "$CONFIG"; then
+	exit 0
+fi
+
+backup="$BACKUP_BASE"
+index=0
+while [ -e "$backup" ]; do
+	index=$((index + 1))
+	backup="${BACKUP_BASE}.${index}"
+done
+
+cp -a "$CONFIG" "$backup"
+rm -f "$CONFIG"
+
+if [ -s "$ROM_CONFIG" ] &&
+	grep -q "config settings 'general'" "$ROM_CONFIG" &&
+	grep -q "option enabled '1'" "$ROM_CONFIG"; then
+	cp -a "$ROM_CONFIG" "$CONFIG"
+else
+	cat > "$CONFIG" <<'EOF'
+config settings 'general'
+	option enabled '1'
+	option profile_mode 'single'
+	option light_level '5'
+	option button_gpio '71'
+	option net_interface 'br-lan'
+	option wan_ip_custom_url 'http://checkip.amazonaws.com'
+	option custom_content 'Roc-Gateway'
+	option http_length '15'
+	option http_cache_secs '60'
+	option weather_city 'auto'
+	option weather_source 'uapis'
+	option weather_format 'simple'
+	option temp_sensors '4'
+	option enable_sleep '0'
+	option disable_led_clock '0'
+	option disable_led_medal '0'
+	option disable_led_up '0'
+	option disable_led_down '0'
+
+config single_module
+	option duration '5'
+	option module 'time_group'
+	option param 'time_sec'
+EOF
+fi
+
+if [ -x /etc/init.d/athena_led ]; then
+	/etc/init.d/athena_led enable >/dev/null 2>&1 || true
+	/etc/init.d/athena_led restart >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/tests/test_athena_led_config_migration_guard.sh
+++ b/tests/test_athena_led_config_migration_guard.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MIGRATION_SCRIPT="$ROOT_DIR/files/etc/uci-defaults/99-athena-led-config-migration"
+
+[ -f "$MIGRATION_SCRIPT" ] || {
+	echo "missing athena LED config migration script"
+	exit 1
+}
+
+grep -q "athena_led.config.enable" "$MIGRATION_SCRIPT" || {
+	echo "migration script does not detect old athena_led config schema"
+	exit 1
+}
+
+grep -q "/rom/etc/config/athena_led" "$MIGRATION_SCRIPT" || {
+	echo "migration script does not restore the package default config"
+	exit 1
+}
+
+grep -q "athena_led.config-migrated" "$MIGRATION_SCRIPT" || {
+	echo "migration script does not keep a backup of the incompatible config"
+	exit 1
+}
+
+grep -q "option enabled '1'" "$MIGRATION_SCRIPT" || {
+	echo "migration script does not provide a v2.x-compatible fallback config"
+	exit 1
+}
+
+echo "athena LED config migration guard passed"


### PR DESCRIPTION
The previous Athena LED plugin used athena_led.config with enable/lightLevel/tempFlag, while the current luci-app-athena-led 2.x plugin reads athena_led.general with enabled/light_level/temp_sensors.

When users keep the old /etc/config/athena_led across sysupgrade, procd can report the service as active without starting an athena-led instance, leaving the RE-CS-02 Athena AX6600 screen blank.

Back up and remove the incompatible old config on first boot, then restore the package default config from /rom/etc/config/athena_led so the new LED plugin can generate/use its expected schema. Fall back to a minimal v2.x-compatible config if the package default is unavailable.

通过测试，需要删除旧固件里面LED配置文件后新插件才能生效